### PR TITLE
No full stop on the publish message

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ const argv = yargs.argv;
     const {published, reason, manifest} = await publish({args: argv._});
 
     if (published) {
-      console.log(`✅ Published ${formatNameAndVersion(manifest)}.`);
+      console.log(`✅ Published ${formatNameAndVersion(manifest)}`);
       return;
     }
 


### PR DESCRIPTION
The full stop on the end of the successful publish message could be confused as part of the version number or accidentally included when highlighting to copy and paste elsewhere.