### PR TITLE
Tag and version suffix checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## Change log
+
+### 1.1.0
+
+- Add dist-tag / version suffix logic for preventing accidentally publishing a tagged release with a real version, or a latest release with a version suffix. ([#4](https://github.com/jameslnewell/publish-if-not-published/pull/4))
+
+### 1.0.0
+
+- Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Change log
 
-### 1.1.0
+### 2.0.0
 
 - Add dist-tag / version suffix logic for preventing accidentally publishing a tagged release with a real version, or a latest release with a version suffix. ([#4](https://github.com/jameslnewell/publish-if-not-published/pull/4))
 

--- a/README.md
+++ b/README.md
@@ -17,3 +17,23 @@ Run `publish-if-not-published` and pass any additional arguments that you would 
 ```bash
 "$(yarn bin)/publish-if-not-published" -- --otp 123456
 ```
+
+### Tags
+
+When specifing a non-latest tag to be published, a suffix should also be appended to the version so as not to use up a semver version on a prerelease.
+
+```json
+{
+  "name": "package",
+  "version": "2.0.0-next.0"
+}
+```
+
+```bash
+"$(yarn bin)/publish-if-not-published" -- --tag next
+```
+
+`publish-if-not-published` checks whether it has been called with a non-latest tag, and the version of the package to prevent:
+
+1. Accidentally publishing a tagged release with a non-suffixed version, or 
+1. Accidentally publishing a latest release with a suffixed version.

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ When specifing a non-latest tag to be published, a suffix should also be appende
 1. Accidentally publishing a tagged release with a non-suffixed version, or 
 1. Accidentally publishing a latest release with a suffixed version.
 
-These checks can be turned off with the `--no-tag-check` flag:
+These checks can be turned off with the `--no-dist-tag-check` flag:
 
 ```bash
-"$(yarn bin)/publish-if-not-published" --no-tag-check -- --tag rc
+"$(yarn bin)/publish-if-not-published" --no-dist-tag-check -- --tag rc
 ```

--- a/README.md
+++ b/README.md
@@ -37,3 +37,9 @@ When specifing a non-latest tag to be published, a suffix should also be appende
 
 1. Accidentally publishing a tagged release with a non-suffixed version, or 
 1. Accidentally publishing a latest release with a suffixed version.
+
+These checks can be turned off with the `--no-tag-check` flag:
+
+```bash
+"$(yarn bin)/publish-if-not-published" --no-tag-check -- --tag rc
+```

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ When specifing a non-latest tag to be published, a suffix should also be appende
 1. Accidentally publishing a tagged release with a non-suffixed version, or 
 1. Accidentally publishing a latest release with a suffixed version.
 
-These checks can be turned off with the `--no-dist-tag-check` flag:
+These checks can be turned off with the `--no-tag-check` flag:
 
 ```bash
-"$(yarn bin)/publish-if-not-published" --no-dist-tag-check -- --tag rc
+"$(yarn bin)/publish-if-not-published" --no-tag-check -- --tag rc
 ```

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
   },
   "dependencies": {
     "@types/node": "^9.4.6",
+    "@types/semver": "^6.2.0",
     "@types/yargs": "^11.1.1",
     "chalk": "^2.4.1",
+    "semver": "^7.1.1",
     "yargs": "^12.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-if-not-published",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Publish a package if the current version isn't already published.",
   "keywords": [
     "npm",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-if-not-published",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Publish a package if the current version isn't already published.",
   "keywords": [
     "npm",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,15 @@ const argv = yargs.argv;
       return;
     }
 
+    if (reason === "missing-suffix") {
+      console.log(`⚠️  Skipped publishing ${formatNameAndVersion(manifest)} because the package is being published as a ${chalk.bold.white("non-latest")} tag and the version has no suffix.`);
+      return;
+    }
+
+    if (reason === "extraneous-suffix") {
+      console.log(`⚠️  Skipped publishing ${formatNameAndVersion(manifest)} because the package is being published as ${chalk.bold.white("latest")} but the version has an extraneous suffix.`);
+      return;
+    }
   } catch (error) {
     console.log(`❌ Failed to publish package:`);
     console.log();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ const argv = yargs.argv;
 
 (async () => {
   try {
-    const {published, reason, manifest} = await publish({tagCheck: argv.tagCheck, args: argv._});
+    const {published, reason, manifest} = await publish({shouldCheckDistTag: argv.distTagCheck, args: argv._});
 
     if (published) {
       console.log(`✅ Published ${formatNameAndVersion(manifest)}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ const argv = yargs.argv;
 
 (async () => {
   try {
-    const {published, reason, manifest} = await publish({shouldCheckDistTag: argv.distTagCheck, args: argv._});
+    const {published, reason, manifest} = await publish({shouldCheckTag: argv.tagCheck, args: argv._});
 
     if (published) {
       console.log(`✅ Published ${formatNameAndVersion(manifest)}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ const argv = yargs.argv;
 
 (async () => {
   try {
-    const {published, reason, manifest} = await publish({args: argv._});
+    const {published, reason, manifest} = await publish({tagCheck: argv.tagCheck, args: argv._});
 
     if (published) {
       console.log(`✅ Published ${formatNameAndVersion(manifest)}`);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,15 @@
+import {isPrerelease} from '.';
 
-it.skip('is just a placeholder', () => {
-  // TODO: write tests
+describe('isPrerelease', () => {
+  it('should return false for non-suffixed versions', () => {
+    expect(isPrerelease('1.0.0')).toBeFalsy();
+    expect(isPrerelease('0.0.0')).toBeFalsy();
+    expect(isPrerelease('1231231.12312319067.8543450')).toBeFalsy();
+  });
+  it('should return true for suffixed versions', () => {
+    expect(isPrerelease('1.0.0-x.0')).toBeTruthy();
+    expect(isPrerelease('0.0.2-rc')).toBeTruthy();
+    expect(isPrerelease('5.2.17-next.123asdcq24raq2')).toBeTruthy();
+    expect(isPrerelease('12.8.3-preview.85')).toBeTruthy();
+  });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -20,6 +20,7 @@ describe('getTagFromArgs', () => {
     expect(getTagFromArgs(['--registry', 'https://registry.npmjs.org/'])).toBeUndefined();
     expect(getTagFromArgs(['--foo', 'bar', '--baz', 'buzz'])).toBeUndefined();
     expect(getTagFromArgs(['--tag'])).toBeUndefined();
+    expect(getTagFromArgs(['--tag', 'latest'])).toBeUndefined();
   });
   it('should return the next item in the args array if tag is set', () => {
     expect(getTagFromArgs(['--tag', 'next'])).toEqual('next');

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import {isPrerelease} from '.';
+import {isPrerelease, getTagFromArgs} from './index';
 
 describe('isPrerelease', () => {
   it('should return false for non-suffixed versions', () => {
@@ -11,5 +11,18 @@ describe('isPrerelease', () => {
     expect(isPrerelease('0.0.2-rc')).toBeTruthy();
     expect(isPrerelease('5.2.17-next.123asdcq24raq2')).toBeTruthy();
     expect(isPrerelease('12.8.3-preview.85')).toBeTruthy();
+  });
+});
+
+describe('getTagFromArgs', () => {
+  it('should return undefined if no dist-tag set', () => {
+    expect(getTagFromArgs()).toBeUndefined();
+    expect(getTagFromArgs(['--registry', 'https://registry.npmjs.org/'])).toBeUndefined();
+    expect(getTagFromArgs(['--foo', 'bar', '--baz', 'buzz'])).toBeUndefined();
+    expect(getTagFromArgs(['--tag'])).toBeUndefined();
+  });
+  it('should return the next item in the args array if tag is set', () => {
+    expect(getTagFromArgs(['--tag', 'next'])).toEqual('next');
+    expect(getTagFromArgs(['--foo', 'bar', '--tag', 'preview', '--baz', 'buzz'])).toEqual('preview');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import * as semver from 'semver';
 export interface PublishOptions {
   cwd?: string;
   args?: string[];
+  tagCheck?: boolean;
 }
 
 export function getTagFromArgs(args: string[] = []) {
@@ -34,7 +35,7 @@ export interface PublishResult {
 
 export default function publish(options: PublishOptions = {}): Promise<PublishResult> {
   return new Promise((resolve, reject) => {
-    const {cwd = process.cwd(), args = []} = options;
+    const {cwd = process.cwd(), tagCheck = true, args = []} = options;
 
     let manifest: {[name: string]: any};
     try {
@@ -56,22 +57,24 @@ export default function publish(options: PublishOptions = {}): Promise<PublishRe
       return;
     }
 
-    if (hasDistTag && !hasSuffix) {
-      resolve({
-        published: false,
-        reason: 'missing-suffix',
-        manifest
-      });
-      return;
-    }
+    if (tagCheck) {
+      if (hasDistTag && !hasSuffix) {
+        resolve({
+          published: false,
+          reason: 'missing-suffix',
+          manifest
+        });
+        return;
+      }
 
-    if (!hasDistTag && hasSuffix) {
-      resolve({
-        published: false,
-        reason: 'extraneous-suffix',
-        manifest
-      });
-      return;
+      if (!hasDistTag && hasSuffix) {
+        resolve({
+          published: false,
+          reason: 'extraneous-suffix',
+          manifest
+        });
+        return;
+      }
     }
 
     const cmd = `npm publish ${args.join(" ")}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as semver from 'semver';
 export interface PublishOptions {
   cwd?: string;
   args?: string[];
-  shouldCheckDistTag?: boolean;
+  shouldCheckTag?: boolean;
 }
 
 export function getTagFromArgs(args: string[] = []) {
@@ -35,7 +35,7 @@ export interface PublishResult {
 
 export default function publish(options: PublishOptions = {}): Promise<PublishResult> {
   return new Promise((resolve, reject) => {
-    const {cwd = process.cwd(), shouldCheckDistTag = true, args = []} = options;
+    const {cwd = process.cwd(), shouldCheckTag = true, args = []} = options;
 
     let manifest: {[name: string]: any};
     try {
@@ -45,7 +45,7 @@ export default function publish(options: PublishOptions = {}): Promise<PublishRe
       return;
     }
 
-    const hasDistTag = getTagFromArgs(args);
+    const hasTag = getTagFromArgs(args);
     const hasSuffix = isPrerelease(manifest.version);
 
     if (manifest.private) {
@@ -57,8 +57,8 @@ export default function publish(options: PublishOptions = {}): Promise<PublishRe
       return;
     }
 
-    if (shouldCheckDistTag) {
-      if (hasDistTag && !hasSuffix) {
+    if (shouldCheckTag) {
+      if (hasTag && !hasSuffix) {
         resolve({
           published: false,
           reason: 'missing-suffix',
@@ -67,7 +67,7 @@ export default function publish(options: PublishOptions = {}): Promise<PublishRe
         return;
       }
 
-      if (!hasDistTag && hasSuffix) {
+      if (!hasTag && hasSuffix) {
         resolve({
           published: false,
           reason: 'extraneous-suffix',

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as semver from 'semver';
 export interface PublishOptions {
   cwd?: string;
   args?: string[];
-  tagCheck?: boolean;
+  shouldCheckDistTag?: boolean;
 }
 
 export function getTagFromArgs(args: string[] = []) {
@@ -35,7 +35,7 @@ export interface PublishResult {
 
 export default function publish(options: PublishOptions = {}): Promise<PublishResult> {
   return new Promise((resolve, reject) => {
-    const {cwd = process.cwd(), tagCheck = true, args = []} = options;
+    const {cwd = process.cwd(), shouldCheckDistTag = true, args = []} = options;
 
     let manifest: {[name: string]: any};
     try {
@@ -57,7 +57,7 @@ export default function publish(options: PublishOptions = {}): Promise<PublishRe
       return;
     }
 
-    if (tagCheck) {
+    if (shouldCheckDistTag) {
       if (hasDistTag && !hasSuffix) {
         resolve({
           published: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,9 @@ export interface PublishOptions {
 
 export function getTagFromArgs(args: string[] = []) {
   if (args.includes("--tag")) {
-    return args[args.indexOf("--tag") + 1];
+    const tagValue = args[args.indexOf("--tag") + 1]
+    // latest is the default
+    return tagValue === 'latest' ? undefined : tagValue;
   }
   return;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export interface PublishOptions {
   args?: string[];
 }
 
-function getTagFromArgs(args: string[]) {
+export function getTagFromArgs(args: string[] = []) {
   if (args.includes("--tag")) {
     return args[args.indexOf("--tag") + 1];
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -176,12 +176,6 @@
   dependencies:
     "@types/babel-types" "*"
 
-"@types/chalk@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-2.2.0.tgz#b7f6e446f4511029ee8e3f43075fb5b73fbaa0ba"
-  dependencies:
-    chalk "*"
-
 "@types/chokidar@^1.7.5":
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/@types/chokidar/-/chokidar-1.7.5.tgz#1fa78c8803e035bed6d98e6949e514b133b0c9b6"
@@ -339,6 +333,11 @@
     "@types/rx-lite-testing" "*"
     "@types/rx-lite-time" "*"
     "@types/rx-lite-virtualtime" "*"
+
+"@types/semver@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.2.0.tgz#d688d574400d96c5b0114968705366f431831e1a"
+  integrity sha512-1OzrNb4RuAzIT7wHSsgZRlMBlNsJl+do6UblR7JMW4oB7bbR+uBEYtUh7gEc/jM84GGilh68lSOokyM/zNUlBA==
 
 "@types/through@*":
   version "0.0.29"
@@ -820,14 +819,6 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@*, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
 chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -837,6 +828,14 @@ chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -3301,6 +3300,11 @@ sax@^1.2.4:
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+semver@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.1.tgz#29104598a197d6cbe4733eeecbe968f7b43a9667"
+  integrity sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Hey James 👋 

We are adding a `publish-preview` script to our monorepo and wanted to do some additional checks to make sure that we are only publishing suffixed-versions to tags, and non-suffixed-versions to latest.

Hope this fits in with your vision for the package 👍 