### PR TITLE
Empty npm stdout handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-if-not-published",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Publish a package if the current version isn't already published.",
   "keywords": [
     "npm",

--- a/src/isPublished.ts
+++ b/src/isPublished.ts
@@ -15,13 +15,14 @@ export function isPublished(name: string, version: string): Promise<boolean> {
         }
       } else {
         try {
-          const json = JSON.parse(stdout);
+          const json = JSON.parse(stdout ? stdout : '{}');
           if (typeof json === 'string') {
             resolve(json === version);
           } else if (Array.isArray(json)) {
             resolve(json.includes(version));
           } else {
-            reject(new Error(`"${cmd}" didn't return an array of versions.`));
+            // Empty stdout with 0 response code indicates no versions.
+            resolve(false);
           }
         } catch (parseError) {
           reject(parseError);


### PR DESCRIPTION
Currently, if `npm` returns a `0` response code with no stdout, `JSON.parse()` throws an exception.
In this case, `isPublished` should return false.

Changes:
- Handle empty / null npm stdout more gracefully
- Treat empty stdout as `isPublished = false`

Please let me know if you want me to bump `package.json`.